### PR TITLE
Use default C++ and use boost::placeholders::_1 to build on Ubuntu 22.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ros_rtsp)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages

--- a/src/image2rtsp.cpp
+++ b/src/image2rtsp.cpp
@@ -159,7 +159,7 @@ void Image2RTSPNodelet::url_connected(string url) {
 
             if (num_of_clients[url]==0) {
                 // Subscribe to the ROS topic
-                subs[url] = nh.subscribe<sensor_msgs::Image>(source, 1, boost::bind(&Image2RTSPNodelet::imageCallback, this, _1, url));
+                subs[url] = nh.subscribe<sensor_msgs::Image>(source, 1, boost::bind(&Image2RTSPNodelet::imageCallback, this, boost::placeholders::_1, url));
             }
             num_of_clients[url]++;
         }


### PR DESCRIPTION
This will likely not build on kinetic but should be fine on melodic and noetic, can make kinetic work if that is a concern